### PR TITLE
Changes dependency on sbt-web from M1 back to SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-testkit" % "2.2.3" % "test"
 )
 
-addSbtPlugin("com.typesafe" % "sbt-js-engine" % "1.0.0-M1")
+addSbtPlugin("com.typesafe" % "sbt-js-engine" % "1.0.0-SNAPSHOT")
 
 scriptedSettings
 


### PR DESCRIPTION
Would like to get the fix for typesafehub/sbt-web#8 pulled into the other snapshots in the sbt-web ecosystem. Seems like the M1 back to SNAPSHOT was missed here.

Related pull request for js-engine: https://github.com/typesafehub/js-engine/pull/4
