### PR TITLE
Update jshint to 2.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-jdk: openjdk6
+jdk: openjdk7
 language: scala
 script: sbt scripted

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val `sbt-jshint` = project in file(".")
 description := "Allows JSHint to be used from within sbt"
 
 libraryDependencies ++= Seq(
-  "org.webjars" % "jshint-node" % "2.6.3-2",
+  "org.webjars.npm" % "jshint" % "2.9.3",
   "org.webjars" % "strip-json-comments" % "1.0.2-1"
 )
 


### PR DESCRIPTION
<s>As of today, jshint 2.9.1 is the latest version available on webjars (refs https://github.com/webjars/jshint/issues/17). This PR updates the dependency to it.</s>

This updates jshint from jshint-node 2.6.3-2 to jshint 2.9.3

I am unsure about the side effects of exchanging the `node` variant to the normal variant, but the tests go through.
