### PR TITLE
Enable caching and update Java from Java6 to Java7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
-jdk: openjdk6
+jdk: openjdk7
 language: scala
 script: sbt scripted
+
+# Use container-based infrastructure
+# See also http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
+sudo: false
+
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete


### PR DESCRIPTION
This PR should just speedup the travis build process.

The commands are taken from http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html

OpenJDK is updated from 6 to 7 to avoid following error message

> java.lang.UnsupportedClassVersionError: org/webjars/WebJarExtractor$Cache : Unsupported major.minor version 51.0
