### PR TITLE
Fix resolution for Coursier / sbt 1.3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,1 @@
-Copyright (C) 2013-2014 Typesafe Inc. <http://www.typesafe.com>
+Copyright (C) 2013-2019 Typesafe Inc. <http://www.typesafe.com>

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ provide a `.jshintrc` file within your project's base directory. If there is no 
 be search for in your home directory. This behaviour can be overridden by using a `JshintKeys.config` setting for the plugin.
 `JshintKeys.config` is used to specify the location of a configuration file.
 
-&copy; 2013-2017 [Lightbend Inc.](https://www.lightbend.com)
+&copy; 2013-2019 [Lightbend Inc.](https://www.lightbend.com)

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,11 @@ developers += Developer(
 )
 
 libraryDependencies ++= Seq(
-  "org.webjars.npm" % "jshint" % "2.9.7",
+  // specs allow [0, 1) but 0.2+ versions want domelementtype > 2 which breaks others
+  "org.webjars.npm" % "dom-serializer" % "0.1.1" force(),
+  // dom-serializer:0.1.1 wants [1.1.1,2), htmlparser2:3.8.3 wants [1.0,1.1) ...
+  "org.webjars.npm" % "entities" % "1.1.1",
+  "org.webjars.npm" % "jshint" % "2.10.2" exclude("org.webjars.npm", "entities"),
   "org.webjars" % "strip-json-comments" % "1.0.2-1"
 )
 


### PR DESCRIPTION
Resolving sbt-jshint in a project using Coursier fails with the webjar conflicts seen in https://github.com/sbt/sbt-jshint/issues/44#issuecomment-549433573. You can reproduce it in this project itself by enabling the latest sbt-coursier plugin.

I published a new webjar of the latest jshint and the conflicts are still present with it, so the exclusion + explicit versions here fix it. This appears to produce an `ivy.xml` that relieves the issue for consuming projects: I published 1.0.7-SNAPSHOT locally and it works in a project where 1.0.6 fails as in #44. 

This also passes `^scripted` for me.