### PR TITLE
Make `require(...)` find `strip-json-comments`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,15 @@ developers += Developer(
 )
 
 libraryDependencies ++= Seq(
-  "org.webjars.npm" % "jshint" % "2.9.7",
-  "org.webjars" % "strip-json-comments" % "1.0.2-1"
+  "org.webjars.npm" % "jshint" % "2.13.6",
+
+  // Multiple strip-json-comments dependencies will be downloaded by webjars extractor.
+  // Therefore we need to add the version we want to use to the require(...) statement.
+  // E.g. when running the scripted test by hand you will find the webjars in:
+  // src/sbt-test/sbt-jshint-plugin/test$ ls -a1 ./project/target/node-modules/webjars/strip-json-comments/
+  // 1.0.2-1
+  // 1.0.4
+  "org.webjars" % "strip-json-comments" % "1.0.2-1" // sync with "var stripJsonComments = require(...)" in src/main/resources/jshint-shell.js
 )
 
 addSbtJsEngine("1.3.5")

--- a/src/main/resources/jshint-shell.js
+++ b/src/main/resources/jshint-shell.js
@@ -22,7 +22,7 @@
     var console = require("console");
     var fs = require("fs");
     var jshint = require("jshint");
-    var stripJsonComments = require("strip-json-comments");
+    var stripJsonComments = require("strip-json-comments/1.0.2-1"); // version of sub-folder defined in build.sbt's libraryDependencies
 
     var SOURCE_FILE_MAPPINGS_ARG = 2;
     var OPTIONS_ARG = 4;


### PR DESCRIPTION
This seems to be caused by a newer webjars-locator version we are using since sbt-web 1.5.x which puts multiple versions of a webjars into subfolders. This wasn't done before, not sure what it did before, maybe choose the highest version and put that directly in the folder.